### PR TITLE
Upgrade to celery 5.3, flower 2.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/python:3.9
 
 RUN apt-get update
-RUN	apt-get --yes install libcairo2-dev rabbitmq-server
+RUN	apt-get --yes install rabbitmq-server
 RUN	mkdir --parents /usr/local/var/postgres
 RUN chown vscode:vscode /usr/local/var/postgres

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ migrate:
 
 .PHONY: celery
 celery:
-	celery worker -A reboot --without-heartbeat --without-gossip --without-mingle
+	CELERY_TRACE_APP=1 celery --app reboot worker --without-heartbeat --without-gossip --without-mingle
 
 .PHONY: clean
 clean:

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-worker: celery worker -A reboot --without-heartbeat --without-gossip --without-mingle
+worker: celery --app worker --without-heartbeat --without-gossip --without-mingle
 web: gunicorn reboot.wsgi --log-level info

--- a/app/worker/tasks/__init__.py
+++ b/app/worker/tasks/__init__.py
@@ -1,13 +1,13 @@
 '''
 Module for tasks to be sent on task queue
 '''
-from celery import task
+from celery import shared_task
 
 from app.worker.app_celery import AppTask
 from .create_receipt import Receiptor
 
 
-@task(bind=True, base=AppTask)
+@shared_task(bind=True, base=AppTask)
 def receiptor(self, queryset, total_count):
     receiptor = Receiptor(queryset, total_count)
     return receiptor()

--- a/app/worker/tasks/exporter.py
+++ b/app/worker/tasks/exporter.py
@@ -1,6 +1,6 @@
 import csv
 
-from celery import task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.core import serializers
 from django.db.models.query import QuerySet
@@ -10,7 +10,7 @@ from app.constants.field_names import CURRENT_FIELDS
 from app.worker.app_celery import AppTask, update_percent
 
 
-@task(bind=True, base=AppTask)
+@shared_task(bind=True, base=AppTask)
 def exporter(self, file_name, qs: QuerySet = None, total_count: int = 0):
     rows = serializers.deserialize('json', qs)
     csv_exporter = CsvExporter(file_name, rows, total_count)

--- a/app/worker/tasks/importers/__init__.py
+++ b/app/worker/tasks/importers/__init__.py
@@ -1,13 +1,14 @@
 """
 Module for csv file importers to be sent to queue
 """
-from celery import task
+from celery import shared_task
 
 from app.worker.app_celery import AppTask
+
 from .historical_data_importer import HistoricalDataImporter
 
 
-@task(bind=True, base=AppTask)
+@shared_task(bind=True, base=AppTask)
 def historical_data_importer(self, csvpath):
     importer = HistoricalDataImporter(csvpath)
     importer()

--- a/reboot/__init__.py
+++ b/reboot/__init__.py
@@ -2,4 +2,4 @@
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app
 
-__all__ = ['celery_app']
+__all__ = ('celery_app',)

--- a/reboot/celery.py
+++ b/reboot/celery.py
@@ -1,10 +1,15 @@
-from celery import Celery
-from django.conf import settings
 import os
 
+from celery import Celery
+
+# Set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'reboot.settings')
 
-app = Celery()
+app = Celery('reboot')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
 app.config_from_object('reboot.celeryconfig')
 
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+# Load task modules from all registered Django apps.
+app.autodiscover_tasks()

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,4 @@ simplejson==3.17.6
 # https://pypi.org/project/whitenoise/6.0.0/
 # whitenoise==6.0.0
 whitenoise==5.0.1
-# https://pypi.org/project/xhtml2pdf/0.2.13/
-xhtml2pdf==0.2.13
+xhtml2pdf~=0.2.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ django-admin-rangefilter==0.8.8
 # https://github.com/mishbahr/django-modeladmin-reorder/issues/52
 # https://pypi.org/project/django-modeladmin-reorder/0.3.1/
 django-modeladmin-reorder==0.3.1
-# https://pypi.org/project/flower/1.0.0/
-flower==1.0.0
+flower~=2.0
 # https://pypi.org/project/gunicorn/20.1.0/
 gunicorn==20.1.0
 # https://pypi.org/project/importlib-metadata/4.8.3/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Commented requirements indicate the latest patches of the earliest releases that support Python 3.9.
 
-# https://pypi.org/project/celery/5.1.2/
-celery[redis]==5.1.2
+celery[redis]~=5.3
 # https://pypi.org/project/Django/2.2.28/
 Django==2.2.28
 # https://pypi.org/project/dj-database-url/1.0.0/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # Commented requirements indicate the latest patches of the earliest releases that support Python 3.9.
 
 # https://pypi.org/project/celery/5.1.2/
-# celery[redis]==5.1.2
-celery[redis]==4.4.7
+celery[redis]==5.1.2
 # https://pypi.org/project/Django/2.2.28/
 Django==2.2.28
 # https://pypi.org/project/dj-database-url/1.0.0/
@@ -15,8 +14,7 @@ django-admin-rangefilter==0.8.8
 # https://pypi.org/project/django-modeladmin-reorder/0.3.1/
 django-modeladmin-reorder==0.3.1
 # https://pypi.org/project/flower/1.0.0/
-# flower==1.0.0
-flower==0.9.7
+flower==1.0.0
 # https://pypi.org/project/gunicorn/20.1.0/
 gunicorn==20.1.0
 # https://pypi.org/project/importlib-metadata/4.8.3/


### PR DESCRIPTION
This pull request upgrades the application to use celery 5.3 and flower 2.0, the latest releases of each package.

I referenced the following articles to make these changes:

- https://docs.celeryq.dev/en/v5.1.2/whatsnew-5.1.html
- https://docs.celeryq.dev/en/v5.1.2/django/first-steps-with-django.html
- https://docs.celeryq.dev/en/v5.1.2/userguide/application.html