### PR TITLE
Fix Worker Command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-worker: celery --app worker --without-heartbeat --without-gossip --without-mingle
+worker: celery --app reboot worker --without-heartbeat --without-gossip --without-mingle
 web: gunicorn reboot.wsgi --log-level info


### PR DESCRIPTION
This pull request fixes the `worker` command in `Procfile` by adding the missing `reboot` app name that was lost in #1.